### PR TITLE
move trusted_domains from vars to defaults

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,7 @@ nextcloud_use_https: true
 nextcloud_webroot: /srv/nextcloud/html
 nextcloud_dataroot: /srv/nextcloud/data
 nextcloud_admin_pw: 'krypt0n!'
+nextcloud_trusted_domains: ['localhost', '{{ nextcloud_fqdn }}']
 
 # PHP-Settings
 nextcloud_max_upload_size: 16G

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,7 +7,6 @@ nextcloud_nginx_ssl_cert_dir: /etc/nginx
 nextcloud_nginx_ssl_cert_key: "{{ nextcloud_nginx_ssl_cert_dir }}/{{ nextcloud_fqdn }}_key.pem"
 nextcloud_nginx_ssl_cert_crt: "{{ nextcloud_nginx_ssl_cert_dir }}/{{ nextcloud_fqdn }}_crt.pem"
 nextcloud_nginx_ssl_cert_ca_chain: "{{ nextcloud_nginx_ssl_cert_dir }}/{{ nextcloud_fqdn }}_ca.pem"
-nextcloud_trusted_domains: ['localhost', '{{ nextcloud_fqdn }}']
 nextcloud_cert_store: "{{ nextcloud_webroot }}/resources/config/ca-bundle.crt"
 nextcloud_admin_user: admin
 nextcloud_mysql_db: nextcloud


### PR DESCRIPTION
Moved trusted_domains from vars to defaults, so it can be modified by the playbook.
(Needed for setups with multiple domains.)